### PR TITLE
cellranger_count.sh: don't check if ref. transcriptome exists

### DIFF
--- a/CellRanger_hsapiens/cellranger_count.sh
+++ b/CellRanger_hsapiens/cellranger_count.sh
@@ -33,11 +33,9 @@ echo "copying FASTQs..."
 rsync -PrhLtv $fastq_path ${fastq_temp} #copy data to /tmp
 echo "...done"
 
-if [ ! -d ${transcriptome_temp} ]; then
-    echo "copying reference transcriptome..."
-    rsync -PrhLtv ${transcriptome} .
-    echo "...done"
-fi
+echo "copying reference transcriptome..."
+rsync -PrhLtv ${transcriptome} .
+echo "...done"
 
 cellranger count \
     --localmem=128 \


### PR DESCRIPTION
We don't need to do this anymore because `rsync` will fail gracefully if the directory exists, unlike `cp`.  