### PR TITLE
Drop hardcoded path from mktemp in job scripts

### DIFF
--- a/ATACseq_footprinting/ATACseq_processing.sh
+++ b/ATACseq_footprinting/ATACseq_processing.sh
@@ -47,7 +47,7 @@ reps=$(basename "${number_replicates}")
 
 echo "number of replicates for ${PREFIX}: $reps"
 
-temp_path=$(mktemp -d /tmp/tmp.XXXXXXXXXX)
+temp_path=$(mktemp -d)
 echo "temp_path is: " $temp_path
 echo "copying bams from the data path..."
 rsync -vur "$bam_path/" $temp_path

--- a/Methylseq/methylseq.sh
+++ b/Methylseq/methylseq.sh
@@ -40,7 +40,7 @@ fastq_temp=$(basename "${fastq_path}")
 line_count=$( wc -l < "${genetic_locations}" )
 total_genomes=$(bc -l <<< "scale=0; (($line_count / 3) - 1)")                                   #the total number of genomes requested to be mapped against
 
-temp_path=$(mktemp -d /tmp/tmp.XXXXXXXXXX)
+temp_path=$(mktemp -d)
 echo "temp_path is: " $temp_path
 echo "copying FASTQs from the data path..."                                                     #copy data from data_path to the temp_path
 rsync -vur "$data_path/fastq/" $temp_path


### PR DESCRIPTION
The `mktemp` command creates a temporary file or directory.  This change
removes the hard-coded `/tmp` path from the two places where `mktemp` is
executed in a job script.

The reason is, in UNIX operating systems (including Linux), there is a
standard[1] environment variable, `TMPDIR`, which system administrators
can tell programs to store data.  On SCG, compute jobs have `TMPDIR` set
to a path that is automatically cleaned up when the job completes.

When you set a hard-coded path in `mktemp`, the command ignores the
`TMPDIR`.  Instead, it is better to either not provide a template at
all, or to provide a template _and_ use the `--tmpdir` option (which
makes your path relative to `TMPDIR`).

[1] IEEE.  Portable Operating System Interface (POSIX(TM)) Base Specifications.
    Issue 7.  Chapter 8.  DOI 10.1109/IEEESTD.2018.8277153.
    Free link at  https://pubs.opengroup.org/onlinepubs/9699919799/