### PR TITLE
Save annotated VCF output separately 

### DIFF
--- a/BWA_CHIP/BWA_CHIP.sh
+++ b/BWA_CHIP/BWA_CHIP.sh
@@ -149,6 +149,11 @@ if [[ $final_output_directory != "none" ]]; then
     mkdir -p "${final_output_directory}"
 fi
 
+if [[ $annotated_output_directory != "none" ]]; then
+    final_output_directory="${annotated_output_directory}/${sample_name}"
+    mkdir -p "${annotated_output_directory}"
+fi
+
 if [[ ${slurm_mode} == true ]]; then
     input_directory="${TMPDIR}/inputs"
     output_directory="${TMPDIR}/outputs/${sample_name}"

--- a/BWA_CHIP/BWA_CHIP.sh
+++ b/BWA_CHIP/BWA_CHIP.sh
@@ -150,7 +150,7 @@ if [[ $final_output_directory != "none" ]]; then
 fi
 
 if [[ $annotated_output_directory != "none" ]]; then
-    final_output_directory="${annotated_output_directory}/${sample_name}"
+    annotated_output_directory="${annotated_output_directory}/${sample_name}"
     mkdir -p "${annotated_output_directory}"
 fi
 

--- a/BWA_CHIP/BWA_CHIP.sh
+++ b/BWA_CHIP/BWA_CHIP.sh
@@ -145,7 +145,8 @@ gatk_command="mamba run -n gatk4 gatk"
 code_directory=$(realpath $(dirname ${BASH_SOURCE[0]}))
 
 if [[ $final_output_directory != "none" ]]; then
-    final_output_directory=${final_output_directory}/${sample_name}
+    final_output_directory="${final_output_directory}/${sample_name}"
+    mkdir -p "${final_output_directory}"
 fi
 
 if [[ ${slurm_mode} == true ]]; then

--- a/BWA_CHIP/BWA_CHIP.sh
+++ b/BWA_CHIP/BWA_CHIP.sh
@@ -390,7 +390,7 @@ if [[ ${run_mutect} == true ]]; then
     if [[ ${run_funcotator} == true ]]; then
         "${code_directory}/funcotator.sh" \
             --filtered_vcf "${output_directory}/${sample_name}_mutect2_filtered.vcf" \
-            --annotated_output_directory= "${annotated_output_directory}" \
+            --annotated_output_directory "${annotated_output_directory}" \
             --reference_genome "${reference_genome}" \
             --funcotator_sources "${funcotator_sources}" \
             --transcript_list "${transcript_list}" \

--- a/BWA_CHIP/BWA_CHIP.sh
+++ b/BWA_CHIP/BWA_CHIP.sh
@@ -32,6 +32,7 @@ check_for_directory() {
 options_array=(
     array_file
     output_directory
+    annotated_output_directory
     varscan_min_coverage
     varscan_min_var_freq
     varscan_max_pvalue
@@ -71,6 +72,8 @@ while true; do
             array_file="${2}"; check_for_file "${1}" "${2}"; shift 2 ;;
         --output_directory )
             final_output_directory="${2}"; check_for_directory "${1}" "${2}"; shift 2 ;;
+        --annotated_output_directory )
+            annotated_output_directory="${2}"; check_for_directory "${1}" "${2}"; shift 2 ;;
         --bam_extension )
             bam_extension="${2}"; shift 2 ;;
         --fastq_extension )
@@ -235,6 +238,8 @@ if [[ ${slurm_mode} == true ]]; then
         #${rsync_command} "${original_normal_pileups_table}" "${normal_pileups_table}"
         #check_for_file "${rsync_command}" "${normal_pileups_table}"
     #fi
+else
+    output_directory=${final_output_directory}
 fi
 
 ##################################################################################################################################
@@ -379,6 +384,7 @@ if [[ ${run_mutect} == true ]]; then
     if [[ ${run_funcotator} == true ]]; then
         "${code_directory}/funcotator.sh" \
             --filtered_vcf "${output_directory}/${sample_name}_mutect2_filtered.vcf" \
+            --annotated_output_directory= "${annotated_output_directory}" \
             --reference_genome "${reference_genome}" \
             --funcotator_sources "${funcotator_sources}" \
             --transcript_list "${transcript_list}" \

--- a/BWA_CHIP/funcotator.sh
+++ b/BWA_CHIP/funcotator.sh
@@ -29,6 +29,7 @@ check_for_directory() {
 
 options_array=(
     filtered_vcf
+    annotated_output_directory
     reference_genome
     funcotator_sources
     transcript_list
@@ -45,6 +46,8 @@ while true; do
     case "${1}" in
         --filtered_vcf )
             filtered_vcf="${2}"; check_for_file "${1}" "${2}"; shift 2 ;;
+        --annotated_output_directory )
+            annotated_output_directory="${2}"; check_for_directory "${1}" "${2}"; shift 2 ;;
         --reference_genome )
             reference_genome="${2}"; check_for_file "${1}" "${2}"; shift 2 ;;
         --funcotator_sources )
@@ -117,5 +120,7 @@ bcftools view "${funcotator_vcf}" | \
     bgzip --stdout > "${funcotator_vcf}.gz"
 tabix --preset vcf --force "${funcotator_vcf}.gz"
 
-bcftools +split-vep --annotation "FUNCOTATION" --columns "${funcotator_columns}" --annot-prefix "funcotator_" "${funcotator_vcf}.gz" | bgzip | sponge "${funcotator_vcf}.gz"
+funcotator_vcf_basename=$(basename ${funcotator_vcf})
+annotated_funcotator_vcf_gz="${annotated_output_directory}/${funcotator_vcf_basename}.gz"
+bcftools +split-vep --annotation "FUNCOTATION" --columns "${funcotator_columns}" --annot-prefix "funcotator_" "${funcotator_vcf}.gz" | bgzip --stdout > "${annotated_funcotator_vcf_gz}"
 tabix --preset vcf --force "${funcotator_vcf}.gz"

--- a/BWA_CHIP/funcotator.sh
+++ b/BWA_CHIP/funcotator.sh
@@ -123,4 +123,4 @@ tabix --preset vcf --force "${funcotator_vcf}.gz"
 funcotator_vcf_basename=$(basename ${funcotator_vcf})
 annotated_funcotator_vcf_gz="${annotated_output_directory}/${funcotator_vcf_basename}.gz"
 bcftools +split-vep --annotation "FUNCOTATION" --columns "${funcotator_columns}" --annot-prefix "funcotator_" "${funcotator_vcf}.gz" | bgzip --stdout > "${annotated_funcotator_vcf_gz}"
-tabix --preset vcf --force "${annotated_funcotator_vcf_gz}.gz"
+tabix --preset vcf --force "${annotated_funcotator_vcf_gz}"

--- a/BWA_CHIP/funcotator.sh
+++ b/BWA_CHIP/funcotator.sh
@@ -123,4 +123,4 @@ tabix --preset vcf --force "${funcotator_vcf}.gz"
 funcotator_vcf_basename=$(basename ${funcotator_vcf})
 annotated_funcotator_vcf_gz="${annotated_output_directory}/${funcotator_vcf_basename}.gz"
 bcftools +split-vep --annotation "FUNCOTATION" --columns "${funcotator_columns}" --annot-prefix "funcotator_" "${funcotator_vcf}.gz" | bgzip --stdout > "${annotated_funcotator_vcf_gz}"
-tabix --preset vcf --force "${funcotator_vcf}.gz"
+tabix --preset vcf --force "${annotated_funcotator_vcf}.gz"

--- a/BWA_CHIP/funcotator.sh
+++ b/BWA_CHIP/funcotator.sh
@@ -123,4 +123,4 @@ tabix --preset vcf --force "${funcotator_vcf}.gz"
 funcotator_vcf_basename=$(basename ${funcotator_vcf})
 annotated_funcotator_vcf_gz="${annotated_output_directory}/${funcotator_vcf_basename}.gz"
 bcftools +split-vep --annotation "FUNCOTATION" --columns "${funcotator_columns}" --annot-prefix "funcotator_" "${funcotator_vcf}.gz" | bgzip --stdout > "${annotated_funcotator_vcf_gz}"
-tabix --preset vcf --force "${annotated_funcotator_vcf}.gz"
+tabix --preset vcf --force "${annotated_funcotator_vcf_gz}.gz"

--- a/BWA_CHIP/mutect2_applet/dxapp.json
+++ b/BWA_CHIP/mutect2_applet/dxapp.json
@@ -62,6 +62,13 @@
             "help": "Path relative to $HOME where pipeline output will be stored (default: outputs)"
         },
         {
+            "name": "annotated_output_directory",
+            "class": "string",
+            "default": "annotated_outputs",
+            "optional": false,
+            "help": "Path relative to $HOME where annotated pipeline output will be stored (default: annotated_outputs)"
+        },
+        {
             "name": "project_id",
             "class": "string",
             "default": "project-G5B07V8JPkg740v9GjfF9PzV",
@@ -269,6 +276,7 @@
         {
             "name": "outputs_folder",
             "class": "array:file",
+            "default": "outputs",
             "help": "Path on DNA Nexus project storage relative to project root where job output will be saved (default: outputs)"
         }
     ],

--- a/BWA_CHIP/mutect2_applet/dxapp.json
+++ b/BWA_CHIP/mutect2_applet/dxapp.json
@@ -274,9 +274,12 @@
     ],
     "outputSpec": [
         {
-            "name": "outputs_folder",
-            "class": "array:file",
-            "help": "Path on DNA Nexus project storage relative to project root where job output will be saved (default: outputs)"
+            "name": "outputs_tar",
+            "class": "array:file"
+        },
+        {
+            "name": "annotated_outputs_tar",
+            "class": "array:file"
         }
     ],
     "runSpec": {

--- a/BWA_CHIP/mutect2_applet/dxapp.json
+++ b/BWA_CHIP/mutect2_applet/dxapp.json
@@ -276,7 +276,6 @@
         {
             "name": "outputs_folder",
             "class": "array:file",
-            "default": "outputs",
             "help": "Path on DNA Nexus project storage relative to project root where job output will be saved (default: outputs)"
         }
     ],

--- a/BWA_CHIP/mutect2_applet/src/submit_cloud.sh
+++ b/BWA_CHIP/mutect2_applet/src/submit_cloud.sh
@@ -46,6 +46,8 @@ function run_job() {
     mkdir --parents "${local_input_directory}"
     local_output_directory="${HOME}/${output_directory}"
     mkdir --parents "${local_output_directory}"
+    local_annotated_output_directory="${HOME}/${annotated_output_directory}"
+    mkdir --parents "${local_annotated_output_directory}"
 
     sample_directory=$(echo "${sample_directory}" | tr '?' ' ')
     parallel -j${n_downloads} "dx download --overwrite ${project_id}:/\"${sample_directory}/{}\" --output ${local_input_directory}/\$(basename {})" < "${local_sample_list}"
@@ -98,13 +100,18 @@ function run_job() {
     "${HOME}/workflows/BWA_CHIP/submit_BWA_CHIP.sh" \
         --input_directory "${local_input_directory}" \
         --output_directory "${local_output_directory}" \
+        --annotated_output_directory "${local_annotated_output_directory}" \
         "${passed_args_array[@]}" \
         "${reference_args_array[@]}"
 
     output_tar="${HOME}/outputs_${array_number}.tar"
     tar --create --file "${output_tar}" "${local_output_directory}"
+    annotated_output_tar="${HOME}/annotated_outputs_${array_number}.tar"
+    tar --create --file "${annotated_output_tar}" "${local_annotated_output_directory}"
     outputs_folder_id=$(dx upload "${output_tar}" --brief)
     dx-jobutil-add-output outputs_tar "${outputs_folder_id}" --class=file
+    annotated_outputs_folder_id=$(dx upload "${annotated_output_tar}" --brief)
+    dx-jobutil-add-output annotated_outputs_tar "${annotated_outputs_folder_id}" --class=file
 }
 
 function main() {
@@ -204,6 +211,7 @@ function main() {
         references_directory
         input_directory
         output_directory
+        annotated_output_directory
         project_id
         bam_extension
         fastq_extension

--- a/BWA_CHIP/mutect2_applet/src/submit_cloud.sh
+++ b/BWA_CHIP/mutect2_applet/src/submit_cloud.sh
@@ -248,6 +248,7 @@ function main() {
 
     for array_number in $(seq 1 "${number_of_batches}"); do
         job_id=$(dx-jobutil-new-job run_job -iarray_number="${array_number}" "${job_args[@]}" --instance-type="${instance_type}")
-        dx-jobutil-add-output outputs_folder "${job_id}:outputs_tar" --class=jobref --array
+        dx-jobutil-add-output outputs_tar "${job_id}:outputs_tar" --class=jobref --array
+        dx-jobutil-add-output annotated_outputs_tar "${job_id}:annotated_outputs_tar" --class=jobref --array
     done
 }

--- a/BWA_CHIP/submit_BWA_CHIP.sh
+++ b/BWA_CHIP/submit_BWA_CHIP.sh
@@ -35,6 +35,7 @@ options_array=(
     input_directory
     input_file_list
     output_directory
+    annotated_output_directory
     bam_extension
     fastq_extension
     assembly
@@ -99,6 +100,8 @@ while true; do
             input_file_list="$2"; check_for_file "${1}" "${2}"; shift 2 ;;
         --output_directory )
             output_directory="$2"; shift 2 ;;
+        --annotated_output_directory )
+            annotated_output_directory="$2"; shift 2 ;;
         --bam_extension )
             bam_extension="$2"; shift 2 ;;
         --fastq_extension )
@@ -478,6 +481,7 @@ fi
 passed_args_array=(
     array_file 
     output_directory 
+    annotated_output_directory 
     bam_extension 
     fastq_extension 
     assembly 


### PR DESCRIPTION
To avoid having to download all the intermediary files, this PR will create a second job output only containing the final, annotated and compressed VCF that will be filtered separately.